### PR TITLE
Eliminate the inactivity timeout

### DIFF
--- a/lib/ld-em-eventsource.rb
+++ b/lib/ld-em-eventsource.rb
@@ -42,7 +42,7 @@ module EventMachine
 
       @last_event_id = nil
       @retry = 3 # seconds
-      @inactivity_timeout = 60 # seconds
+      @inactivity_timeout = 0 # seconds
 
       @opens = []
       @errors = []


### PR DESCRIPTION
See here for details on inactivity timeouts:

https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts

Causes https://github.com/launchdarkly/ruby-client/issues/52
